### PR TITLE
Adding yum_lock_timeout to yum task

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Optional:
 - `fluentd_groups`: List of additional groups the Fluentd/td-agent user should be a member of, e.g. to allow access to restricted logs, default none
 - `fluentd_plugins`: List of Fluentd plugins to install, default none. See https://www.fluentd.org/plugins
 - `fluentd_env`: Dictionary of environment variables
+- `fluentd_yum_lock_timeout`: Time in seconds to wait for the yum process to free the lockfile
 
 
 Configuration

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,6 @@ fluentd_env: {}
 
 # The Treasure Data stable fluentd package is called td-agent
 fluentd_name: td-agent
+
+# Time in seconds to wait for the yum process to free the lock file
+fluentd_yum_lock_timeout: 30

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Install Fluentd log collector
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.3
+  min_ansible_version: 2.8
   platforms:
     - name: EL
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,7 @@
   yum:
     name: "{{ fluentd_name }}"
     state: present
+    lock_timeout: "{{ fluentd_yum_lock_timeout }}"
   notify:
     - restart fluentd
 


### PR DESCRIPTION
This parameter avoid the "yum lockfile is held by another process" issue.

Tests:

Without lock file:

`ansible-role-fluentd : fluentd | install ---- 12.72s`

With lock file:

`ansible-role-fluentd : fluentd | install ---- 35.31s`

This means the task waits for the yum lock file to be freed